### PR TITLE
Implement WithEdgeSeparator

### DIFF
--- a/treeprint.go
+++ b/treeprint.go
@@ -295,6 +295,10 @@ var (
 // It can be updated and used as the default value.
 var IndentSize = 3
 
+var (
+	defaultEdgeSeparator = " "
+)
+
 type options struct {
 	edgeTypeLink, edgeTypeMid, edgeTypeEnd *EdgeType
 	indentSize                             *int
@@ -350,8 +354,7 @@ func evalOptions(opts ...Option) *options {
 		o.indentSize = &IndentSize
 	}
 	if o.edgeSeparator == nil {
-		sep := " "
-		o.edgeSeparator = &sep
+		o.edgeSeparator = &defaultEdgeSeparator
 	}
 	return &o
 }

--- a/treeprint.go
+++ b/treeprint.go
@@ -220,11 +220,12 @@ func (o *options) printValues(wr io.Writer,
 	val := o.renderValue(level, node)
 	meta := node.Meta
 
+	sep := *o.edgeSeparator
 	if meta != nil {
-		fmt.Fprintf(wr, "%s [%v]  %v\n", edge, meta, val)
+		fmt.Fprintf(wr, "%s%s[%v]  %v\n", edge, sep, meta, val)
 		return
 	}
-	fmt.Fprintf(wr, "%s %v\n", edge, val)
+	fmt.Fprintf(wr, "%s%s%v\n", edge, sep, val)
 }
 
 func isEnded(levelsEnded []int, level int) bool {
@@ -297,6 +298,7 @@ var IndentSize = 3
 type options struct {
 	edgeTypeLink, edgeTypeMid, edgeTypeEnd *EdgeType
 	indentSize                             *int
+	edgeSeparator                          *string
 }
 type Option func(*options)
 
@@ -324,6 +326,12 @@ func WithIndentSize(indentSize int) Option {
 	}
 }
 
+func WithEdgeSeparator(sep string) Option {
+	return func(o *options) {
+		o.edgeSeparator = &sep
+	}
+}
+
 func evalOptions(opts ...Option) *options {
 	var o options
 	for _, opt := range opts {
@@ -340,6 +348,10 @@ func evalOptions(opts ...Option) *options {
 	}
 	if o.indentSize == nil {
 		o.indentSize = &IndentSize
+	}
+	if o.edgeSeparator == nil {
+		sep := " "
+		o.edgeSeparator = &sep
 	}
 	return &o
 }

--- a/treeprint_test.go
+++ b/treeprint_test.go
@@ -222,14 +222,6 @@ func TestEdgeTypeAndIndent(t *testing.T) {
 func TestStringWithOptions(t *testing.T) {
 	assert := assert.New(t)
 
-	// Restore to the original values
-	defer func(link, mid, end EdgeType, indent int) {
-		EdgeTypeLink = link
-		EdgeTypeMid = mid
-		EdgeTypeEnd = end
-		IndentSize = indent
-	}(EdgeTypeLink, EdgeTypeMid, EdgeTypeEnd, IndentSize)
-
 	tree := New()
 	tree.AddBranch("one").AddNode("two")
 	foo := tree.AddBranch("foo")
@@ -238,18 +230,20 @@ func TestStringWithOptions(t *testing.T) {
 
 	actual := tree.StringWithOptions(
 		WithEdgeTypeLink("|"),
-		WithEdgeTypeMid("+-"),
-		WithEdgeTypeEnd("+-"),
-		WithIndentSize(2))
+		WithEdgeTypeMid("+"),
+		WithEdgeTypeEnd("+"),
+		WithIndentSize(0),
+		WithEdgeSeparator(""),
+	)
 	expected := `.
-+- one
-|  +- two
-+- foo
-   +- bar
-   |  +- a
-   |  +- b
-   |  +- c
-   +- end
++one
+|+two
++foo
+ +bar
+ |+a
+ |+b
+ |+c
+ +end
 `
 	assert.Equal(expected, actual)
 }


### PR DESCRIPTION
This PR introduces `WithEdgeSeparator` option to customize separator between edge and node text.